### PR TITLE
Add release helper and structure workflow files

### DIFF
--- a/.woodpecker/publish-release.yml
+++ b/.woodpecker/publish-release.yml
@@ -2,33 +2,8 @@ variables:
   - &golang 'golang:1.21'
 
 steps:
-  lint:
-    group: test
-    image: *golang
-    commands:
-      - make vet
-      - make formatcheck
-
-  test:
-    group: test
-    image: *golang
-    commands:
-      - make test
-
-  build:
-    image: woodpeckerci/plugin-docker-buildx
-    settings:
-      dockerfile: Dockerfile.multiarch
-      dry_run: true
-      repo: woodpeckerci/plugin-s3
-      tags: latest
-      platforms: linux/arm/v7,linux/arm64/v8,linux/amd64,linux/ppc64le,windows/amd64,darwin/amd64,darwin/arm64,freebsd/arm64,freebsd/amd64,openbsd/arm64,openbsd/amd64
-    when:
-      branch: ${CI_REPO_DEFAULT_BRANCH}
-      event: pull_request
-
   publish-next:
-    image: woodpeckerci/plugin-docker-buildx
+    image: woodpeckerci/plugin-docker-buildx:2.1.0
     settings:
       dockerfile: Dockerfile.multiarch
       repo: woodpeckerci/plugin-s3
@@ -40,7 +15,7 @@ steps:
       event: push
 
   publish-tag:
-    image: woodpeckerci/plugin-docker-buildx
+    image: woodpeckerci/plugin-docker-buildx:2.1.0
     settings:
       dockerfile: Dockerfile.multiarch
       repo: woodpeckerci/plugin-s3

--- a/.woodpecker/publish-release.yml
+++ b/.woodpecker/publish-release.yml
@@ -1,3 +1,5 @@
+depends_on: [test]
+
 variables:
   - &golang 'golang:1.21'
 

--- a/.woodpecker/release-helper.yml
+++ b/.woodpecker/release-helper.yml
@@ -1,0 +1,14 @@
+steps:
+  release-helper:
+    image: woodpeckerci/plugin-ready-release-go:0.6.1
+    pull: true
+    settings:
+      release_branch: ${CI_REPO_DEFAULT_BRANCH}
+      forge_type: github
+      git_email: woodpecker-bot@obermui.de
+      github_token:
+        from_secret: GITHUB_TOKEN
+
+when:
+  event: push
+  branch: ${CI_REPO_DEFAULT_BRANCH}

--- a/.woodpecker/release-helper.yml
+++ b/.woodpecker/release-helper.yml
@@ -1,7 +1,6 @@
 steps:
   release-helper:
     image: woodpeckerci/plugin-ready-release-go:0.6.1
-    pull: true
     settings:
       release_branch: ${CI_REPO_DEFAULT_BRANCH}
       forge_type: github

--- a/.woodpecker/test-pr.yml
+++ b/.woodpecker/test-pr.yml
@@ -1,0 +1,29 @@
+variables:
+  - &golang 'golang:1.21'
+
+when:
+  branch: ${CI_REPO_DEFAULT_BRANCH}
+  event: pull_request
+
+steps:
+  lint:
+    group: test
+    image: *golang
+    commands:
+      - make vet
+      - make formatcheck
+
+  test:
+    group: test
+    image: *golang
+    commands:
+      - make test
+
+  build:
+    image: woodpeckerci/plugin-docker-buildx:2.1.0
+    settings:
+      dockerfile: Dockerfile.multiarch
+      dry_run: true
+      repo: woodpeckerci/plugin-s3
+      tags: latest
+      platforms: linux/arm/v7,linux/arm64/v8,linux/amd64,linux/ppc64le,windows/amd64,darwin/amd64,darwin/arm64,freebsd/arm64,freebsd/amd64,openbsd/arm64,openbsd/amd64

--- a/.woodpecker/test.yml
+++ b/.woodpecker/test.yml
@@ -2,8 +2,10 @@ variables:
   - &golang 'golang:1.21'
 
 when:
-  branch: ${CI_REPO_DEFAULT_BRANCH}
-  event: pull_request
+  - event: pull_request
+  - event: push
+    branch:
+      - ${CI_REPO_DEFAULT_BRANCH}
 
 steps:
   lint:


### PR DESCRIPTION
So far everything was done in one workflow file. Splitting steps into dedicated files like we do in other repos already helps for overview and future modifications.

Also added tags to images.