### PR TITLE
Renovate: run tests on renovate/ branches

### DIFF
--- a/.woodpecker/test.yml
+++ b/.woodpecker/test.yml
@@ -6,6 +6,7 @@ when:
   - event: push
     branch:
       - ${CI_REPO_DEFAULT_BRANCH}
+      - "renovate/*"
 
 steps:
   lint:


### PR DESCRIPTION
This way we can run tests on renovate branches only and make use of branch automerge (and reduce PR noise). A PR will opened if a CI run on the branch fails.