### PR TITLE
Fix typo in docker image names

### DIFF
--- a/.woodpecker/publish.yml
+++ b/.woodpecker/publish.yml
@@ -5,7 +5,7 @@ variables:
       platforms: 'linux/arm/v7,linux/arm64/v8,linux/amd64,linux/ppc64le,windows/amd64,darwin/amd64,darwin/arm64,freebsd/arm64,freebsd/amd64,openbsd/arm64,openbsd/amd64'
       dockerfile: Dockerfile.multiarch
       auto_tag: true
-      repo: woodpeckerci/plugin-docker-buildx,codeberg.org/woodpecker-plugins/docker-buildx
+      repo: woodpeckerci/plugin-s3,codeberg.org/woodpecker-plugins/s3
   - &login_setting # Default DockerHub login
     - registry: https://index.docker.io/v1/
       username: woodpeckerbot


### PR DESCRIPTION
Was publishing over plugin-docker-buildx images