### PR TITLE
Support skipping upload if file already exists

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -153,3 +153,6 @@ env_file
 
 compress
 : prior to upload, compress files and use gzip content-encoding (false by default)
+
+overwrite
+: overwrite existing files (true by default)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/woodpecker-ci/plugin-s3
 go 1.21
 
 require (
-	github.com/aws/aws-sdk-go v1.54.6
+	github.com/aws/aws-sdk-go v1.54.14
 	github.com/joho/godotenv v1.5.1
 	github.com/mattn/go-zglob v0.0.4
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go v1.54.6 h1:HEYUib3yTt8E6vxjMWM3yAq5b+qjj/6aKA62mkgux9g=
-github.com/aws/aws-sdk-go v1.54.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
+github.com/aws/aws-sdk-go v1.54.14 h1:llJ60MzLzovyDE/rEDbUjS1cICh7krk1PwQwNlKRoeQ=
+github.com/aws/aws-sdk-go v1.54.14/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/main.go
+++ b/main.go
@@ -20,40 +20,40 @@ func main() {
 		&cli.StringFlag{
 			Name:    "endpoint",
 			Usage:   "endpoint for the s3 connection",
-			EnvVars: []string{"PLUGIN_ENDPOINT,S3_ENDPOINT"},
+			EnvVars: []string{"PLUGIN_ENDPOINT", "S3_ENDPOINT"},
 		},
 		&cli.StringFlag{
 			Name:    "access-key",
 			Usage:   "aws access key",
-			EnvVars: []string{"PLUGIN_ACCESS_KEY,AWS_ACCESS_KEY_ID"},
+			EnvVars: []string{"PLUGIN_ACCESS_KEY", "AWS_ACCESS_KEY_ID"},
 		},
 		&cli.StringFlag{
 			Name:    "secret-key",
 			Usage:   "aws secret key",
-			EnvVars: []string{"PLUGIN_SECRET_KEY,AWS_SECRET_ACCESS_KEY"},
+			EnvVars: []string{"PLUGIN_SECRET_KEY", "AWS_SECRET_ACCESS_KEY"},
 		},
 		&cli.StringFlag{
 			Name:    "assume-role",
 			Usage:   "aws iam role to assume",
-			EnvVars: []string{"PLUGIN_ASSUME_ROLE,ASSUME_ROLE"},
+			EnvVars: []string{"PLUGIN_ASSUME_ROLE", "ASSUME_ROLE"},
 		},
 		&cli.StringFlag{
 			Name:    "assume-role-session-name",
 			Usage:   "aws iam role session name to assume",
 			Value:   "woodpecker-s3",
-			EnvVars: []string{"PLUGIN_ASSUME_ROLE_SESSION_NAME,ASSUME_ROLE_SESSION_NAME"},
+			EnvVars: []string{"PLUGIN_ASSUME_ROLE_SESSION_NAME", "ASSUME_ROLE_SESSION_NAME"},
 		},
 		&cli.StringFlag{
 			Name:    "bucket",
 			Usage:   "aws bucket",
 			Value:   "us-east-1",
-			EnvVars: []string{"PLUGIN_BUCKET,S3_BUCKET"},
+			EnvVars: []string{"PLUGIN_BUCKET", "S3_BUCKET"},
 		},
 		&cli.StringFlag{
 			Name:    "region",
 			Usage:   "aws region",
 			Value:   "us-east-1",
-			EnvVars: []string{"PLUGIN_REGION,S3_REGION"},
+			EnvVars: []string{"PLUGIN_REGION", "S3_REGION"},
 		},
 		&cli.StringFlag{
 			Name:    "acl",
@@ -129,6 +129,11 @@ func main() {
 			Usage:   "prior to upload, compress files and use gzip content-encoding",
 			EnvVars: []string{"PLUGIN_COMPRESS"},
 		},
+		&cli.BoolFlag{
+			Name:    "overwrite",
+			Usage:   "overwrite existing files",
+			EnvVars: []string{"PLUGIN_OVERWRITE"},
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -162,6 +167,7 @@ func run(c *cli.Context) error {
 		PathStyle:             c.Bool("path-style"),
 		DryRun:                c.Bool("dry-run"),
 		Compress:              c.Bool("compress"),
+		Overwrite:             c.Bool("overwrite"),
 	}
 
 	return plugin.Exec()

--- a/plugin.go
+++ b/plugin.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -94,6 +95,8 @@ type Plugin struct {
 	DryRun bool
 	// Compress objects and upload with Content-Encoding: gzip
 	Compress bool
+	// Overwrite existing files
+	Overwrite bool
 }
 
 // Exec runs the plugin
@@ -165,13 +168,6 @@ func (p *Plugin) Exec() error {
 			}
 		}
 
-		// log file for debug purposes.
-		log.WithFields(log.Fields{
-			"name":   match,
-			"bucket": p.Bucket,
-			"target": target,
-		}).Info("Uploading file")
-
 		// when executing a dry-run we exit because we don't actually want to
 		// upload the file to S3.
 		if p.DryRun {
@@ -195,57 +191,149 @@ func (p *Plugin) Exec() error {
 			ACL:    &(p.Access),
 		}
 
-		if contentType != "" {
-			putObjectInput.ContentType = aws.String(contentType)
+		// Check if the object exists
+		headObjectInput := &s3.HeadObjectInput{
+			Bucket: &(p.Bucket),
+			Key:    &target,
 		}
 
-		if contentEncoding != "" {
-			putObjectInput.ContentEncoding = aws.String(contentEncoding)
-		}
-
-		if cacheControl != "" {
-			putObjectInput.CacheControl = aws.String(cacheControl)
-		}
-
-		if p.Encryption != "" {
-			putObjectInput.ServerSideEncryption = aws.String(p.Encryption)
-		}
-
-		if p.StorageClass != "" {
-			putObjectInput.StorageClass = &(p.StorageClass)
-		}
-
-		// optionally compress
-		if p.Compress {
-			gr, err := gzip.NewReader(f)
-			if err != nil {
-				log.WithFields(log.Fields{
-					"error": err,
-					"file":  match,
-				}).Error("Problem gzipping file")
-				return err
-			}
-			// wrap with gzip
-			putObjectInput.Body = &gzipReadSeeker{rs: f, z: gr}
-			// set encoding
-			putObjectInput.ContentEncoding = aws.String("gzip")
-		} else {
-			putObjectInput.Body = f
-		}
-
-		// upload
-		_, err = client.PutObject(putObjectInput)
-
+		_, err = client.HeadObject(headObjectInput)
 		if err != nil {
-			log.WithFields(log.Fields{
-				"name":   match,
-				"bucket": p.Bucket,
-				"target": target,
-				"error":  err,
-			}).Error("Could not upload file")
+			// If the error indicates the object does not exist, upload the file
+			if aerr, ok := err.(awserr.Error); ok && aerr.Code() == s3.ErrCodeNoSuchKey {
 
-			return err
+				if contentType != "" {
+					putObjectInput.ContentType = aws.String(contentType)
+				}
+
+				if contentEncoding != "" {
+					putObjectInput.ContentEncoding = aws.String(contentEncoding)
+				}
+
+				if cacheControl != "" {
+					putObjectInput.CacheControl = aws.String(cacheControl)
+				}
+
+				if p.Encryption != "" {
+					putObjectInput.ServerSideEncryption = aws.String(p.Encryption)
+				}
+
+				if p.StorageClass != "" {
+					putObjectInput.StorageClass = &(p.StorageClass)
+				}
+
+				// optionally compress
+				if p.Compress {
+					gr, err := gzip.NewReader(f)
+					if err != nil {
+						log.WithFields(log.Fields{
+							"error": err,
+							"file":  match,
+						}).Error("Problem gzipping file")
+						return err
+					}
+					// wrap with gzip
+					putObjectInput.Body = &gzipReadSeeker{rs: f, z: gr}
+					// set encoding
+					putObjectInput.ContentEncoding = aws.String("gzip")
+				} else {
+					putObjectInput.Body = f
+				}
+
+				// Upload the object
+				log.WithFields(log.Fields{
+					"name":   match,
+					"bucket": p.Bucket,
+					"target": target,
+				}).Info("Uploading file")
+
+				// do upload
+				_, err = client.PutObject(putObjectInput)
+
+				if err != nil {
+					log.WithFields(log.Fields{
+						"name":   match,
+						"bucket": p.Bucket,
+						"target": target,
+						"error":  err,
+					}).Error("Could not upload file")
+
+					return err
+				}
+			} else {
+				// Handle other errors
+			}
+		} else {
+
+			if !p.Overwrite {
+				// Object exists, write log message
+				log.WithFields(log.Fields{
+					"name":   match,
+					"bucket": p.Bucket,
+					"target": target,
+				}).Info("File already exists, skipping upload due to overwrite=false")
+			} else {
+
+				if contentType != "" {
+					putObjectInput.ContentType = aws.String(contentType)
+				}
+
+				if contentEncoding != "" {
+					putObjectInput.ContentEncoding = aws.String(contentEncoding)
+				}
+
+				if cacheControl != "" {
+					putObjectInput.CacheControl = aws.String(cacheControl)
+				}
+
+				if p.Encryption != "" {
+					putObjectInput.ServerSideEncryption = aws.String(p.Encryption)
+				}
+
+				if p.StorageClass != "" {
+					putObjectInput.StorageClass = &(p.StorageClass)
+				}
+
+				// optionally compress
+				if p.Compress {
+					gr, err := gzip.NewReader(f)
+					if err != nil {
+						log.WithFields(log.Fields{
+							"error": err,
+							"file":  match,
+						}).Error("Problem gzipping file")
+						return err
+					}
+					// wrap with gzip
+					putObjectInput.Body = &gzipReadSeeker{rs: f, z: gr}
+					// set encoding
+					putObjectInput.ContentEncoding = aws.String("gzip")
+				} else {
+					putObjectInput.Body = f
+				}
+
+				log.WithFields(log.Fields{
+					"name":   match,
+					"bucket": p.Bucket,
+					"target": target,
+				}).Info("Uploading file")
+
+				// do upload
+				_, err = client.PutObject(putObjectInput)
+
+				if err != nil {
+					log.WithFields(log.Fields{
+						"name":   match,
+						"bucket": p.Bucket,
+						"target": target,
+						"error":  err,
+					}).Error("Could not upload file")
+
+					return err
+				}
+			}
 		}
+
 		f.Close()
 	}
 


### PR DESCRIPTION
## Background

Currently, files are always uploaded to the remote side, even if they didn't change between runs. This causes new versions to be created, incurring potentially unneeded costs and resource waste.

In some cases overwrite might be desired, e.g. for backups, as the files might have changed on disk.
In other scenarios, the CI might be building idempotent assets, in which case "overwrite" is not desired, and the upload should be skipped.

The default will still be `overwrite=true`, i.e. it won't break any workflow in use.

## Solution

Add param `overwrite=true/false` which skips the upload in case the file already exists. This saves bandwith and storage space on the remote side. 

## Implementation

Before doing anything, a call to `HeadObjectInput` is done which checks if the file already exists. If so, the upload is skipped.

The implementation could potentially be improved by checking the sha of the object on both sides and only skip the upload if both are identical. The current solution is sufficient for my use case, though.